### PR TITLE
upgraded some raw pointers into smart pointers

### DIFF
--- a/source/AudioSettingsComponent.cpp
+++ b/source/AudioSettingsComponent.cpp
@@ -35,18 +35,21 @@ audioSettingsComponent::audioSettingsComponent(juce::AudioDeviceManager& parentD
 
   startTimer(50);
 
-  button.setButtonText("Audio Settings");
-  button.onClick = [&] {
-    this->window.launchAsync();
-    window.content.set(this, false);
+  button = std::make_unique<juce::TextButton>();
+  window = std::make_unique<juce::DialogWindow::LaunchOptions>();
+
+  button->setButtonText("Audio Settings");
+  button->onClick = [&] {
+    this->window->launchAsync();
+    window->content.set(this, false);
   };
 
-  window.dialogTitle = "Audio Settings";
-  window.escapeKeyTriggersCloseButton = true;
-  window.resizable = true;
-  window.useBottomRightCornerResizer = true;
-  window.useNativeTitleBar = false;
-  window.content.set(this, false);
+  window->dialogTitle = "Audio Settings";
+  window->escapeKeyTriggersCloseButton = true;
+  window->resizable = true;
+  window->useBottomRightCornerResizer = true;
+  window->useNativeTitleBar = false;
+  window->content.set(this, false);
 }
 
 audioSettingsComponent::~audioSettingsComponent() {

--- a/source/AudioSettingsComponent.hpp
+++ b/source/AudioSettingsComponent.hpp
@@ -7,9 +7,8 @@
 // your module headers visible.
 #include <juce_audio_devices/juce_audio_devices.h>
 #include <juce_audio_utils/juce_audio_utils.h>
-#include <juce_gui_extra/juce_gui_extra.h>
-
 #include <juce_dsp/juce_dsp.h>
+#include <juce_gui_extra/juce_gui_extra.h>
 //==============================================================================
 class audioSettingsComponent : public juce::Component,
                                public juce::ChangeListener,
@@ -23,8 +22,9 @@ class audioSettingsComponent : public juce::Component,
 
   void resized() override;
 
-  juce::TextButton button;                   // button to open Audio Settings window
-  juce::DialogWindow::LaunchOptions window;  // dialog window containing Audio Settings
+  std::unique_ptr<juce::TextButton> button;  // button to open Audio Settings window
+  std::unique_ptr<juce::DialogWindow::LaunchOptions>
+    window;  // dialog window containing Audio Settings
 
  private:
   void changeListenerCallback(juce::ChangeBroadcaster*) override;

--- a/source/MainComponent.cpp
+++ b/source/MainComponent.cpp
@@ -45,11 +45,12 @@ MainComponent::MainComponent()
   audioGraph->addConnection({{audioInputNode->nodeID, 0}, {spectrogramNode->nodeID, 0}});
   // This is the best way I've found to get the editor and be able to display it. Just have your
   // mainComponent own a pointer to an editor, then point it to the editor when it's created.
-  spectrogramEditor = spectrogramNode->getProcessor()->createEditor();
+  spectrogramEditor =
+    std::unique_ptr<juce::AudioProcessorEditor>(spectrogramNode->getProcessor()->createEditor());
 
-  audioSettings.button.setBounds(getLocalBounds().removeFromTop(50));
-  addAndMakeVisible(audioSettings.button);
-  addAndMakeVisible(spectrogramEditor);
+  audioSettings.button->setBounds(getLocalBounds().removeFromTop(50));
+  addAndMakeVisible(audioSettings.button.get());
+  addAndMakeVisible(spectrogramEditor.get());
 }
 // TrackGroup* trackGroupPtr = dynamic_cast<TrackGroup*>(graphElementList.data()[groupID].get());
 //==============================================================================
@@ -74,7 +75,7 @@ void MainComponent::resized() {
   // This is called when the MainComponent is resized.
   // If you add any child components, this is where you should
   // update their positions.
-  audioSettings.button.setBounds(getLocalBounds().removeFromTop(50));
+  audioSettings.button->setBounds(getLocalBounds().removeFromTop(50));
 }
 
 MainComponent::~MainComponent() {

--- a/source/MainComponent.hpp
+++ b/source/MainComponent.hpp
@@ -45,8 +45,8 @@ class MainComponent : public juce::Component, private juce::Timer {
   juce::AudioProcessorGraph::Node::Ptr audioInputNode;   // access to hardware input
   juce::AudioProcessorGraph::Node::Ptr audioOutputNode;  // access to hardware output
   juce::AudioProcessorGraph::Node::Ptr testToneNode;
-  juce::AudioProcessorGraph::Node::Ptr spectrogramNode;  // Spectrogram
-  juce::AudioProcessorEditor* spectrogramEditor;         // Spectrogram editor
+  juce::AudioProcessorGraph::Node::Ptr spectrogramNode;           // Spectrogram
+  std::unique_ptr<juce::AudioProcessorEditor> spectrogramEditor;  // Spectrogram editor
   // this DSP chain will be executed by the processorPlayer
   juce::AudioProcessorPlayer processorPlayer;
   // Audio Settings window for changing IO settings at runtime


### PR DESCRIPTION
I figured out how to allow a unique pointer to take ownership of a raw pointer. Needed because CreateEditor() returns a raw pointer and I wanted the editor to be owned by mainComponent to avoid leaks.

The syntax for giving a raw pointer to a unique_ptr is:
std::unique_ptr<type> foo;
foo = std::unique_ptr<type>(*bar);
or 
foo = std::unique_ptr<type>(functionThatReturnsRawPtr());